### PR TITLE
Fix bug.

### DIFF
--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -463,6 +463,9 @@ class QueryExecutor(object):
                 self.data_source.org, self.data_source,
                 self.query_hash, self.query, data,
                 run_time, utils.utcnow())
+#########################################[UPDATE]#########################################
+            models.db.session.commit()
+#########################################[UPDATE]#########################################
             self._log_progress('checking_alerts')
             for query_id in updated_query_ids:
                 check_alerts_for_query.delay(query_id)


### PR DESCRIPTION
Every time we get a result of a query, program would use last query result to evaluate whether to trigger alert or not firstly and then save this query result into database. So maybe the query result doesn't meet the condition of an alert when the alert is triggered.